### PR TITLE
[hotfix](#72): 테스트용 가격 콘솔 출력 삭제

### DIFF
--- a/src/components/lectureCard/LectureCard.jsx
+++ b/src/components/lectureCard/LectureCard.jsx
@@ -52,7 +52,6 @@ function LectureCard({ lecture, type = 'MAIN' }) {
         )}
         {type === 'MAIN' && (
           <div className="price-enrollment">
-            {console.log(lecture.price)}
             <div className="price">{lecture.price?.toLocaleString()}원</div>
             <div className="enrollment">수강생 {lecture.enrollmentCount}명</div>
           </div>


### PR DESCRIPTION
## 구현 내용
1. 테스트용 가격 콘솔 출력 삭제

close #72 